### PR TITLE
Task 7 add title model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+my-sms/backups/*
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/my-sms/Gemfile
+++ b/my-sms/Gemfile
@@ -19,7 +19,7 @@ end
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.6.0'
-  gem 'factory_bot_rails', '~> 4.10.0'
+  gem 'factory_bot_rails', '~> 4.10.0', require: false
   gem 'test-unit'
   gem 'reek'
   gem 'byebug'

--- a/my-sms/app/models/student.rb
+++ b/my-sms/app/models/student.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class Student < ActiveRecord::Base
-  attr_accessible :title, :first_name, :middle_name, :last_name, :email,
+  attr_accessible :first_name, :middle_name, :last_name, :email,
                   :birth_date, :gender
+  
+  has_one :title
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/my-sms/app/models/student.rb
+++ b/my-sms/app/models/student.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Student < ActiveRecord::Base
-  attr_accessible :first_name, :middle_name, :last_name, :email,
+  attr_accessible :title_id, :first_name, :middle_name, :last_name, :email,
                   :birth_date, :gender
   belongs_to :title
 

--- a/my-sms/app/models/student.rb
+++ b/my-sms/app/models/student.rb
@@ -3,8 +3,7 @@
 class Student < ActiveRecord::Base
   attr_accessible :first_name, :middle_name, :last_name, :email,
                   :birth_date, :gender
-  
-  has_one :title
+  belongs_to :title
 
   validates :first_name, presence: true
   validates :last_name, presence: true
@@ -15,4 +14,9 @@ class Student < ActiveRecord::Base
   validates :birth_date, presence: true
 
   DEFAULT_PER_PAGE = 10
+
+  # defer to title name by default
+  def title(model = false)
+    model ? super : super&.name
+  end
 end

--- a/my-sms/app/models/title.rb
+++ b/my-sms/app/models/title.rb
@@ -1,0 +1,5 @@
+class Title < ActiveRecord::Base
+  attr_accessible :name
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/my-sms/app/views/students/_form.html.erb
+++ b/my-sms/app/views/students/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <%= f.label :title, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
-      <%= f.text_field :title, class: 'form-control' %>
+      <%= f.collection_select(:title_id, Title.all, :id, :name, prompt: true, class: 'form-control') %>
     </div>
   </div>
   <div class="form-group">

--- a/my-sms/db/migrate/20210208041633_create_titles.rb
+++ b/my-sms/db/migrate/20210208041633_create_titles.rb
@@ -16,7 +16,7 @@ class CreateTitles < ActiveRecord::Migration
 
     # create titles table
     create_table :titles do |t|
-      t.string :name
+      t.string :name, null: false
 
       t.timestamps
     end

--- a/my-sms/db/migrate/20210208041633_create_titles.rb
+++ b/my-sms/db/migrate/20210208041633_create_titles.rb
@@ -1,0 +1,70 @@
+class CreateTitles < ActiveRecord::Migration
+  def up
+    available_titles = %w[Mr Mrs Miss Ms Master]
+
+    # do not perform migration if any unexpected titles found in Students
+    # may be more efficient to do via SQL query?
+    Student.find_in_batches do |batch|
+      batch.uniq{|s| s[:title]}.each do |s|
+        if available_titles.exclude? s.title
+          raise "Unexpected Student title #{s.title} in "\
+          "Student id #{s.id}. Migration expects titles "\
+          "in Students column to be one of #{available_titles}."
+        end
+      end
+    end
+
+    # create titles table
+    create_table :titles do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    # pre-populate titles with english honorifics
+    available_titles.each do |name|
+      Title.create({ name: name })
+    end
+
+    # cache titles from db to avoid multiple queries
+    title_name_to_id = {}
+    Title.all.each do |title|
+      title_name_to_id[title.name] = title.id
+    end
+
+    # update students table
+    change_table :students do |t|
+      t.references :title
+    end
+
+    # add title model association
+    # without making assumptions about model
+    Student.reset_column_information
+    Student.find_each do |student|
+      student.update_attribute(:title_id, title_name_to_id.fetch(student.title, nil))
+      student.save
+    end
+
+    # remove old title (string) column
+    remove_column :students, :title
+  end
+
+  def down
+    # create temporary title_string column
+    add_column :students, :title_string, :string
+
+    # undo title model association without assuming title implementation in model
+    Student.find_each do |student|
+      student.update_attribute(:title_string, Title.find(student.title_id).name)
+    end
+
+    # remove title (model) column and rename title_string to title
+    change_table :students do |t|
+      t.remove :title_id
+      t.rename :title_string, :title 
+    end
+
+    # drop titles table
+    drop_table :titles
+  end
+end

--- a/my-sms/db/migrate/20210208041633_create_titles.rb
+++ b/my-sms/db/migrate/20210208041633_create_titles.rb
@@ -1,18 +1,18 @@
 class CreateTitles < ActiveRecord::Migration
-  def up
-    available_titles = %w[Mr Mrs Miss Ms Master]
+  HONORIFICS = %w[Mr Mrs Miss Ms Master]
 
-    # do not perform migration if any unexpected titles found in Students
-    # may be more efficient to do via SQL query?
-    Student.find_in_batches do |batch|
-      batch.uniq{|s| s[:title]}.each do |s|
-        if available_titles.exclude? s.title
-          raise "Unexpected Student title #{s.title} in "\
-          "Student id #{s.id}. Migration expects titles "\
-          "in Students column to be one of #{available_titles}."
-        end
-      end
+  def report_student_titles
+    invalid_titles = Student.where("title NOT IN (?)", HONORIFICS)
+    invalid_titles.each do |title|
+    logger.warn "Unexpected Student title #{s.title} in "\
+         "Student id #{s.id}. Migration expects titles "\
+         "in Students column to be one of #{HONORIFICS}."
     end
+  end
+
+  def up
+    # warn of any students with unexpected titles
+    report_student_titles
 
     # create titles table
     create_table :titles do |t|
@@ -22,48 +22,12 @@ class CreateTitles < ActiveRecord::Migration
     end
 
     # pre-populate titles with english honorifics
-    available_titles.each do |name|
+    HONORIFICS.each do |name|
       Title.create({ name: name })
     end
-
-    # cache titles from db to avoid multiple queries
-    title_name_to_id = {}
-    Title.all.each do |title|
-      title_name_to_id[title.name] = title.id
-    end
-
-    # update students table
-    change_table :students do |t|
-      t.references :title
-    end
-
-    # add title model association
-    # without making assumptions about model
-    Student.reset_column_information
-    Student.find_each do |student|
-      student.update_attribute(:title_id, title_name_to_id.fetch(student.title, nil))
-      student.save
-    end
-
-    # remove old title (string) column
-    remove_column :students, :title
   end
 
   def down
-    # create temporary title_string column
-    add_column :students, :title_string, :string
-
-    # undo title model association without assuming title implementation in model
-    Student.find_each do |student|
-      student.update_attribute(:title_string, Title.find(student.title_id).name)
-    end
-
-    # remove title (model) column and rename title_string to title
-    change_table :students do |t|
-      t.remove :title_id
-      t.rename :title_string, :title 
-    end
-
     # drop titles table
     drop_table :titles
   end

--- a/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
+++ b/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
@@ -1,11 +1,5 @@
 class MoveStudentTitleStrToTitleModel < ActiveRecord::Migration
   def up
-    # cache titles from db to avoid multiple queries
-    title_name_to_id = {}
-    Title.all.each do |title|
-      title_name_to_id[title.name] = title.id
-    end
-
     # update students table
     change_table :students do |t|
       t.rename(:title, :title_old)

--- a/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
+++ b/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
@@ -1,0 +1,44 @@
+class MoveStudentTitleStrToTitleModel < ActiveRecord::Migration
+  def up
+    # cache titles from db to avoid multiple queries
+    title_name_to_id = {}
+    Title.all.each do |title|
+      title_name_to_id[title.name] = title.id
+    end
+
+    # update students table
+    change_table :students do |t|
+      t.rename(:title, :title_old)
+      t.references :title
+    end
+
+    # add title model association
+    # without making assumptions about model
+    # add any titles not already in the db
+    Student.reset_column_information
+    Student.find_each do |student|
+      title = Title.where(name: student[:title_old]).first_or_create
+      student.update_attribute(:title_id, title.id)
+      student.save
+    end
+
+    # remove old title (string) column
+    remove_column :students, :title_old
+  end
+
+  def down
+    # re-create string title column
+    change_table :students do |t|
+      t.string :title_str
+    end
+
+    # undo title model association without assuming title implementation in model
+    Student.find_each do |student|
+      student.update_attribute(:title_str, Title.find(student[:title_id]).name)
+    end
+
+    # remove old title (model) column and rename title_str to title
+    remove_column :students, :title_id
+    rename_column :students, :title_str, :title
+  end
+end

--- a/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
+++ b/my-sms/db/migrate/20210212025754_move_student_title_str_to_title_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MoveStudentTitleStrToTitleModel < ActiveRecord::Migration
   def up
     # update students table
@@ -6,18 +8,7 @@ class MoveStudentTitleStrToTitleModel < ActiveRecord::Migration
       t.references :title
     end
 
-    # add title model association
-    # without making assumptions about model
-    # add any titles not already in the db
-    Student.reset_column_information
-    Student.find_each do |student|
-      title = Title.where(name: student[:title_old]).first_or_create
-      student.update_attribute(:title_id, title.id)
-      student.save
-    end
-
-    # remove old title (string) column
-    remove_column :students, :title_old
+    logger.warn 'Run rake db:migrate:migrate_students to convert existing title Strings in title_old column.'
   end
 
   def down

--- a/my-sms/db/schema.rb
+++ b/my-sms/db/schema.rb
@@ -14,6 +14,7 @@
 ActiveRecord::Schema.define(:version => 20210212025754) do
 
   create_table "students", :force => true do |t|
+    t.string   "title_old"
     t.string   "first_name"
     t.string   "middle_name"
     t.string   "last_name"

--- a/my-sms/db/schema.rb
+++ b/my-sms/db/schema.rb
@@ -11,10 +11,9 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20210128041035) do
+ActiveRecord::Schema.define(:version => 20210208041633) do
 
   create_table "students", :force => true do |t|
-    t.string   "title"
     t.string   "first_name"
     t.string   "middle_name"
     t.string   "last_name"
@@ -23,6 +22,13 @@ ActiveRecord::Schema.define(:version => 20210128041035) do
     t.string   "gender"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.integer  "title_id"
+  end
+
+  create_table "titles", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
 end

--- a/my-sms/db/schema.rb
+++ b/my-sms/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20210208041633) do
+ActiveRecord::Schema.define(:version => 20210212025754) do
 
   create_table "students", :force => true do |t|
     t.string   "first_name"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(:version => 20210208041633) do
   end
 
   create_table "titles", :force => true do |t|
-    t.string   "name"
+    t.string   "name",       :null => false
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/my-sms/lib/tasks/migrate_student_title.rake
+++ b/my-sms/lib/tasks/migrate_student_title.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :migrate do
+    # add title model association
+    # without making assumptions about model
+    # add any titles not already in the db
+    desc 'Convert strings in title_old column to title model.'
+    task student_titles: :environment do
+      if Student.column_names.exclude? 'title_old'
+        raise 'Could not find title_old column in students table. Abandoning.'
+      end
+
+      Student.find_each do |student|
+        title = Title.where(name: student[:title_old]).first_or_create
+        student.update_attribute(:title_id, title.id)
+        student.save
+      end
+    end
+  end
+end

--- a/my-sms/lib/tasks/migrate_student_title.rake
+++ b/my-sms/lib/tasks/migrate_student_title.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-namespace :db do
+namespace :data do
   namespace :migrate do
     # add title model association
     # without making assumptions about model

--- a/my-sms/lib/tasks/snapshot.rake
+++ b/my-sms/lib/tasks/snapshot.rake
@@ -1,0 +1,24 @@
+require 'fileutils'
+
+# from https://gist.github.com/stevebartholomew/50180/749a222426d440f1b6feb70c9575a750fa08b0a9
+
+namespace :db do
+  desc "Backup MySQL database using mysqldump."
+  task snapshot: :environment do
+    settings = Rails.configuration.database_configuration[Rails.env]
+    output_file = Rails.root.join('backups', "#{settings['database']}-#{Time.now.strftime('%Y%m%d-%H:%M')}.sql")
+    FileUtils.mkdir_p Rails.root.join('backups')
+
+    system("mysqldump -h #{settings['host']} -u #{settings['username']} -p#{settings['password']} #{settings['database']} > #{output_file}")
+  end
+
+  namespace :snapshot do
+    desc "Load dumped MySQL database."
+    task :load, [:timestamp] => [:environment] do |task, args|
+      settings = Rails.configuration.database_configuration[Rails.env]
+      output_file = Rails.root.join('backups', "#{settings['database']}-#{args.timestamp}.sql")
+
+      system("mysql -h #{settings['host']} -u #{settings['username']} -p#{settings['password']} #{settings['database']} < #{output_file}")
+    end
+  end
+end

--- a/my-sms/spec/decorators/student_decorator_spec.rb
+++ b/my-sms/spec/decorators/student_decorator_spec.rb
@@ -6,7 +6,7 @@ describe StudentDecorator do
   it 'formats a full name with title, first name, middle name, last name' do
     student = build(
       :student,
-      title: 'Mr',
+      title: FactoryBot.build(:title, name: 'Mr'),
       first_name: 'John',
       middle_name: 'Adam',
       last_name: 'Smith'

--- a/my-sms/spec/decorators/student_decorator_spec.rb
+++ b/my-sms/spec/decorators/student_decorator_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 describe StudentDecorator do
+  let(:title) { build(:title, name: 'Mr') }
+
   it 'formats a full name with title, first name, middle name, last name' do
     student = build(
       :student,
-      title: FactoryBot.build(:title, name: 'Mr'),
+      title: title,
       first_name: 'John',
       middle_name: 'Adam',
       last_name: 'Smith'

--- a/my-sms/spec/factories/students.rb
+++ b/my-sms/spec/factories/students.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :student do
-    title { %w[Mr Mrs Miss Ms].sample }
+    association :title, strategy: :build
     first_name 'John'
     middle_name 'Alan'
     last_name 'Smith'

--- a/my-sms/spec/factories/titles.rb
+++ b/my-sms/spec/factories/titles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :title do
+    name { %w[Mr Mrs Miss Ms Master].sample }
+  end
+end

--- a/my-sms/spec/models/title_spec.rb
+++ b/my-sms/spec/models/title_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Title, type: :model do
 
   context 'a title with the same name exists' do
     let(:title) { build(:title, name: 'honorific') }
-    let(:other_title) { create(:title, name: 'honorific') }
+    let!(:other_title) { create(:title, name: 'honorific') }
 
     before { other_title }
 
     it 'is is invalid with a duplicate name' do
-      should be_invalid
+      is_expected.to be_invalid
     end
   end
 end

--- a/my-sms/spec/models/title_spec.rb
+++ b/my-sms/spec/models/title_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Title, type: :model do
     let(:title) { build(:title, name: 'honorific') }
     let!(:other_title) { create(:title, name: 'honorific') }
 
-    before { other_title }
-
     it 'is is invalid with a duplicate name' do
       is_expected.to be_invalid
     end

--- a/my-sms/spec/models/title_spec.rb
+++ b/my-sms/spec/models/title_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Title, type: :model do
+  subject { title }
+  let(:title) { build(:title, title_params) }
+  let(:title_params) { {} }
+
+  context 'with valid params' do
+    it { should validate_presence_of(:name) }
+  end
+
+  context 'a title with the same name exists' do
+    let(:title) { build(:title, name: 'honorific') }
+    let(:other_title) { create(:title, name: 'honorific') }
+
+    before { other_title }
+
+    it 'is is invalid with a duplicate name' do
+      should be_invalid
+    end
+  end
+end

--- a/my-sms/spec/spec_helper.rb
+++ b/my-sms/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'factory_bot_rails'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Description
Create a Title model, populate it, and associate with Student model.
Assume this app is in production and there is data in the Students.title attr.

All tasks now complete.

## Breakdown of Commits
Add rake snapshot task : a74efac
 - Dump database in case everything goes irrevocably wrong
 
Migrate new title model : 415594a
 - Create new Title model
 - Create new titles table
 - Populate titles table with basic honorifics
 - Add Title association to Student model (has_one)
 - Update student table to reference Title model (title_id) and remove old title string column
 - Perform migration

Make tables name column non nullable : 14c14305da823123d7a32351cae62a6dcab11775

Refactor title migration : 453cd248af4c2a2ecca026d7bcae849771f6fa83
 - Unrecognised old titles in the students table are added to the titles table as part of the migration
 - If there are unrecognised titles in the students table warn instead of refusing to migrate
 - Run migration as two steps:
     - Create and populate titles table
     - Change Student title column from str to Title model
 - Find invalid titles via query interface
 - Access model properties via hash interface

Add title model association to Student : dfcd3ef2d13962d846d873b62f57f8db3744b3a8
 - Add one way belongs_to association
 - Override title getter to defer to title name unless specified

Update factories : 2bac8b9cdb43ef584aa5f341f3fadd5d7f89d74f
 - Add titles factory
 - Replace title on students factory to title association
 - Make factories migration friendly by only auto-loading factories when running specs

Fix full name spec to use Title association in factory : 0086c36ef1f1a88a0e987056de7804432141a52e

Add title model specs : fa498c484ce73c961075a7bcca20559da49e0d08

Remove leftover code that does nothing : dc0b638c58afe8b0c687e17b0e8882dd74c29a29

Keep old title column in migration : c5609c85cda148522e852927f980dc94c5ab2025
 - Extract title conversion to rake task

Refactor title spec : 9c1858a113f78d27f678467ebe5a7b6fb3efd5ed
 - Replace before filter with let bang method
 - Use expect syntax over should syntax

Refactor student decorate spec : fac18efd3fd5586517307c55737ab9d93f8b5dc9
 - Extract building of title association out into a let method

Change student title conversion rake task namespace : a13ee0af7704fc8eaa27b8d8702af1fedf76395a

Add dropdown for title selection : a96adfe1d74cb41cfc3a6f8044e513f952f70c31
 - Include collection select generated from Title collection
 - Add attr_accessor for title_id to Student model

Remove unnecessary before method : 91ddbb4af7744ba024098c91f9ab52348f7369f6

#### TODO Checklist
* [x] Migrate data from Student.title to the Title model. **\*\* in progress \*\***
  - [x] Perform migration
  - [x] Create and update specs
  - [x] Update model/controller code to work with Title model
  - Specs now succeed
* [x] Remove the Student.title attr
* [x] For the Student Edit page, add a dropdown to the title input box that will now pull from the Title model.


## Screenshot
![image](https://user-images.githubusercontent.com/41467557/108007210-7e62d400-7051-11eb-8fe7-8021e1a2fd67.png)
