### PR TITLE
Task 15.3 add course institute association views

### DIFF
--- a/my-sms/app/decorators/course_decorator.rb
+++ b/my-sms/app/decorators/course_decorator.rb
@@ -2,6 +2,7 @@
 
 class CourseDecorator < Draper::Decorator
   delegate_all
+  decorates_association :institute
 
   def self.collection_decorator_class
     PaginatingDecorator

--- a/my-sms/app/decorators/institute_decorator.rb
+++ b/my-sms/app/decorators/institute_decorator.rb
@@ -6,4 +6,8 @@ class InstituteDecorator < Draper::Decorator
   def self.collection_decorator_class
     PaginatingDecorator
   end
+
+  def to_s
+    name
+  end
 end

--- a/my-sms/app/models/institute.rb
+++ b/my-sms/app/models/institute.rb
@@ -8,8 +8,4 @@ class Institute < ActiveRecord::Base
   validates :name, presence: true
 
   DEFAULT_PER_PAGE = 10
-
-  def to_s
-    name
-  end
 end

--- a/my-sms/app/models/institute.rb
+++ b/my-sms/app/models/institute.rb
@@ -8,4 +8,8 @@ class Institute < ActiveRecord::Base
   validates :name, presence: true
 
   DEFAULT_PER_PAGE = 10
+
+  def to_s
+    name
+  end
 end

--- a/my-sms/app/views/courses/_form.html.haml
+++ b/my-sms/app/views/courses/_form.html.haml
@@ -1,5 +1,9 @@
 = form_for @course, html: { class: "form-horizontal course" } do |f|
   %div.form-group
+    = f.label :institute, class: 'control-label col-lg-2'
+    %div.col-lg-10
+      = f.collection_select(:institute_id, Institute.all, :id, :name, class: 'form-control')
+  %div.form-group
     = f.label :name, class: 'control-label col-lg-2'
     %div.col-lg-10
       = f.text_field :name, class: 'form-control'

--- a/my-sms/app/views/courses/index.html.haml
+++ b/my-sms/app/views/courses/index.html.haml
@@ -1,3 +1,3 @@
-- display_attrs = %i[id name number_of_semesters allocation start_date end_date]
+- display_attrs = %i[id name number_of_semesters allocation start_date end_date institute]
 = render partial: 'shared/crud_models',
   locals: {model_class: Course, model_collection: @courses, display_attrs: display_attrs}

--- a/my-sms/app/views/courses/show.html.haml
+++ b/my-sms/app/views/courses/show.html.haml
@@ -1,9 +1,9 @@
 :ruby
-  display_attrs = %i[id name description number_of_semesters allocation start_date end_date]
+  display_attrs = %i[id name description number_of_semesters allocation start_date end_date institute]
   display_ovrd = {
-    number_of_semesters: { heading: Course.human_attribute_name('Semesters') },
-    start_date: { value: l(@course.start_date, format: :long) },
-    end_date: { value: l(@course.end_date, format: :long) }
+  number_of_semesters: { heading: Course.human_attribute_name('Semesters') },
+  start_date: { value: l(@course.start_date, format: :long) },
+  end_date: { value: l(@course.end_date, format: :long) }
   }
 
 = render partial: 'shared/model_attr_list',

--- a/my-sms/app/views/courses/show.html.haml
+++ b/my-sms/app/views/courses/show.html.haml
@@ -1,9 +1,9 @@
 :ruby
   display_attrs = %i[id name description number_of_semesters allocation start_date end_date institute]
   display_ovrd = {
-  number_of_semesters: { heading: Course.human_attribute_name('Semesters') },
-  start_date: { value: l(@course.start_date, format: :long) },
-  end_date: { value: l(@course.end_date, format: :long) }
+    number_of_semesters: { heading: Course.human_attribute_name('Semesters') },
+    start_date: { value: l(@course.start_date, format: :long) },
+    end_date: { value: l(@course.end_date, format: :long) }
   }
 
 = render partial: 'shared/model_attr_list',

--- a/my-sms/app/views/institutes/_course.html.haml
+++ b/my-sms/app/views/institutes/_course.html.haml
@@ -1,0 +1,1 @@
+%p= link_to course.name, course

--- a/my-sms/app/views/institutes/show.html.haml
+++ b/my-sms/app/views/institutes/show.html.haml
@@ -1,3 +1,7 @@
--  display_attrs = %i[id name]
+:ruby
+  display_attrs = %i[id name courses]
+  display_ovrd = {
+  courses: { value: render(partial: 'course', collection: @institute.courses) }
+  }
 = render partial: 'shared/model_attr_list',
-  locals: {model_instance: @institute, display_attrs: display_attrs, display_ovrd: nil}
+  locals: {model_instance: @institute, display_attrs: display_attrs, display_ovrd: display_ovrd}

--- a/my-sms/lib/tasks/generate_demo_data.rake
+++ b/my-sms/lib/tasks/generate_demo_data.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc 'Generate demo data using FactoryBot.'
+  task generate: :environment do
+    require 'factory_bot_rails'
+    80.times { FactoryBot.create(:student, :demo) }
+    30.times { FactoryBot.create(:institute, :demo, with_courses: true) }
+  end
+end

--- a/my-sms/spec/factories/courses.rb
+++ b/my-sms/spec/factories/courses.rb
@@ -4,8 +4,6 @@ require 'faker'
 
 FactoryBot.define do
   factory :course do
-    transient { with_institute { true } }
-
     sequence(:name) { |n| "Course #{n}" }
     description 'This is a course description.'
     allocation { rand(1..50) }
@@ -19,7 +17,11 @@ FactoryBot.define do
       description { Faker::Lorem.paragraph }
       start_date Faker::Date.between(from: '2014-01-1', to: '2014-06-15')
       end_date Faker::Date.between(from: '2014-06-16', to: '2014-12-30')
-      institute { with_institute ? association(:institute_demo) : nil }
+      institute { association(:institute, :demo) }
+    end
+
+    trait :no_institute do
+      institute nil
     end
   end
 end

--- a/my-sms/spec/factories/courses.rb
+++ b/my-sms/spec/factories/courses.rb
@@ -4,6 +4,8 @@ require 'faker'
 
 FactoryBot.define do
   factory :course do
+    transient { with_institute { true } }
+
     sequence(:name) { |n| "Course #{n}" }
     description 'This is a course description.'
     allocation { rand(1..50) }
@@ -12,12 +14,12 @@ FactoryBot.define do
     end_date 2.years.ago.to_date
     institute
 
-    factory :course_demo, class: :course do
+    trait :demo do
       name { Faker::Educator.course_name }
       description { Faker::Lorem.paragraph }
       start_date Faker::Date.between(from: '2014-01-1', to: '2014-06-15')
       end_date Faker::Date.between(from: '2014-06-16', to: '2014-12-30')
-      institute { association :institute_demo }
+      institute { with_institute ? association(:institute_demo) : nil }
     end
   end
 end

--- a/my-sms/spec/factories/institutes.rb
+++ b/my-sms/spec/factories/institutes.rb
@@ -6,9 +6,10 @@ FactoryBot.define do
   factory :institute do
     transient { with_courses { false } }
     sequence(:name) { |n| "Institute #{n}" }
-  end
-  trait :demo do
-    name { [Faker::Educator.university, Faker::Educator.secondary_school].sample }
-    courses { with_courses ? Array.new(rand(8)) { association(:course) } : [] }
+    courses { with_courses ? Array.new(rand(8)) { association(:course, with_institute: false) } : [] }
+    trait :demo do
+      name { [Faker::Educator.university, Faker::Educator.secondary_school].sample }
+      courses { with_courses ? Array.new(rand(8)) { association(:course, :demo, with_institute: false) } : [] }
+    end
   end
 end

--- a/my-sms/spec/factories/institutes.rb
+++ b/my-sms/spec/factories/institutes.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
   factory :institute do
     transient { with_courses { false } }
     sequence(:name) { |n| "Institute #{n}" }
-    courses { with_courses ? Array.new(rand(8)) { association(:course, with_institute: false) } : [] }
+    courses { with_courses ? Array.new(rand(8)) { association(:course, :no_institute) } : [] }
     trait :demo do
       name { [Faker::Educator.university, Faker::Educator.secondary_school].sample }
-      courses { with_courses ? Array.new(rand(8)) { association(:course, :demo, with_institute: false) } : [] }
+      courses { with_courses ? Array.new(rand(8)) { association(:course, :demo, :no_institute) } : [] }
     end
   end
 end

--- a/my-sms/spec/factories/students.rb
+++ b/my-sms/spec/factories/students.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     birth_date 10.years.ago
     gender { ['male', 'female', nil].sample }
   end
-  factory :student_demo, class: :student do
+  trait :demo do
     title_id { [nil, *Title.all.map(&:id)].sample }
     first_name { Faker::Name.first_name }
     middle_name { [nil, Faker::Name.middle_name].sample }


### PR DESCRIPTION
## Description
Part 3 of Task 15. Task 15 is now complete.

Add gui features for the course and institute model association as follows:
- Add a dropdown to list available institutes on the course edit/create pages.
- Add institute name to course show page
- Display list of courses on institute show page
Also added a rake task to automatically generate demo data.

## Breakdown of Commits
Display institute name on course listing : 847a3c7
    
 - Overload to_s on institute to display name

Add edit dropdown to course form : a21934b

Add list of course links to institute show page : 0b84d78
    
 - Create _course partial

Add rake task for generating demo data : 8af01b8
    
 - Add option to create an associated institute on courses factory to prevent factory recursion
 - Use demo course factory for course association on demo institute factory
 - Change separate demo factories to a trait on the parent factory


#### TODO Checklist
* [x] Update Course Edit Page, add a new input field dropdown listing available Institutes 
* [x] Update Course List page to display Institute name 
* [x] Update the Institute List page, displaying all courses within an institute where the course name is the link to the Course Show page

  
#### Screenshot (If applicable)
![image](https://user-images.githubusercontent.com/41467557/108923362-c9519c80-768c-11eb-8e8e-929e3e253ef9.png)
![image](https://user-images.githubusercontent.com/41467557/108923427-e6866b00-768c-11eb-892a-b37a5019dfdd.png)
![image](https://user-images.githubusercontent.com/41467557/108923403-d8d0e580-768c-11eb-879a-e71a7d7e8e2f.png)
